### PR TITLE
Feat : 분실습득 검색 기능(제목+본문) 구현

### DIFF
--- a/src/main/java/org/ayu/doyouknowback/lost/controller/LostController.java
+++ b/src/main/java/org/ayu/doyouknowback/lost/controller/LostController.java
@@ -36,6 +36,17 @@ public class LostController {
         return ResponseEntity.status(HttpStatus.OK).body(lostDetailResponseDTO);
     }
 
+    //검색 조회
+    @GetMapping("/search")
+    public ResponseEntity<Page<LostResponseDTO>> getSearchLost(
+            @RequestParam String value,
+            @RequestParam(required = false, defaultValue = "0") int page,
+            @RequestParam(required = false, defaultValue = "10") int size,
+            @RequestParam(required = false, defaultValue = "id,desc") String sort) {
+        Page<LostResponseDTO> lostResponseDTOList = lostService.getSearch(value, page, size, sort);
+        return ResponseEntity.status(HttpStatus.OK).body(lostResponseDTOList);
+    }
+
     //데이터 저장
     @PostMapping("/addLost")
     public ResponseEntity<String> createLost(@RequestBody List<LostRequestDTO> lostRequestDTOList){

--- a/src/main/java/org/ayu/doyouknowback/lost/repository/LostRepository.java
+++ b/src/main/java/org/ayu/doyouknowback/lost/repository/LostRepository.java
@@ -8,4 +8,6 @@ import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface LostRepository extends JpaRepository<Lost, Long> {
     Page<Lost> findAll(Pageable pageable);
+
+    Page<Lost> findByLostTitleContainingOrLostBodyContaining(String value, String value1, Pageable pageable);
 }

--- a/src/main/java/org/ayu/doyouknowback/lost/service/LostService.java
+++ b/src/main/java/org/ayu/doyouknowback/lost/service/LostService.java
@@ -57,6 +57,20 @@ public class LostService {
         return new PageImpl<>(lostDTO, pageable, lostEntity.getTotalElements());
     }
 
+    public Page<LostResponseDTO> getSearch(String value, int page, int size, String sort) {
+        String[] sortParams = sort.split(",");
+        Sort sorting = Sort.by(Sort.Direction.fromString(sortParams[1]), sortParams[0]);
+        Pageable pageable = PageRequest.of(page, size, sorting);
+        Page<Lost> lostEntity = lostRepository.findByLostTitleContainingOrLostBodyContaining(value, value, pageable);
+
+        List<LostResponseDTO> lostDTO = new ArrayList<>();
+        for(Lost lost : lostEntity){
+            lostDTO.add(LostResponseDTO.fromEntity(lost));
+        }
+
+        return new PageImpl<>(lostDTO, pageable, lostEntity.getTotalElements());
+    }
+
     public LostDetailResponseDTO getfindById(Long lostId) {
         Optional<Lost> lostOptional = lostRepository.findById(lostId);
 
@@ -79,6 +93,4 @@ public class LostService {
 
         lostRepository.saveAll(lostEntity);
     }
-
-
 }


### PR DESCRIPTION
### PR 타입
[✅] 기능 추가
[ ] 기능 삭제
[ ] 버그 수정
[ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트

### 반영 브랜치
 dev ← lost/search

### 검증 방법
#### 1. 검색 (post) : http://localhost:8080/lost/search?value=값
현재 api는 제목과 내용에 value값이 포함 되어 있으면 값을 찾습니다.
```
{
    "content": [
        {
            "id": 197,
            "lostTitle": "우산 분실물",
            "lostWriter": "학생지원과",
            "lostDate": "25.04.25"
        }
    ],
    "pageable": {
        "pageNumber": 0,
        "pageSize": 10,
        "sort": {
            "empty": false,
            "sorted": true,
            "unsorted": false
        },
        "offset": 0,
        "paged": true,
        "unpaged": false
    },
    "last": true,
    "totalElements": 1,
    "totalPages": 1,
    "first": true,
    "numberOfElements": 1,
    "size": 10,
    "number": 0,
    "sort": {
        "empty": false,
        "sorted": true,
        "unsorted": false
    },
    "empty": false
}
```
