### PR TITLE
Fix : 공지사항(Notice) 검색 예외 에러

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -28,6 +28,7 @@ dependencies {
     compileOnly 'org.projectlombok:lombok'
     annotationProcessor 'org.projectlombok:lombok'
     developmentOnly 'org.springframework.boot:spring-boot-devtools'
+
     runtimeOnly 'com.mysql:mysql-connector-j'
     testImplementation 'org.springframework.boot:spring-boot-starter-test'
     testImplementation 'org.springframework.security:spring-security-test'

--- a/src/main/java/org/ayu/doyouknowback/config/FirebaseConfig.java
+++ b/src/main/java/org/ayu/doyouknowback/config/FirebaseConfig.java
@@ -1,44 +1,44 @@
-package org.ayu.doyouknowback.config;
-
-import com.google.auth.oauth2.GoogleCredentials;
-import com.google.firebase.FirebaseApp;
-import com.google.firebase.FirebaseOptions;
-import com.google.firebase.messaging.FirebaseMessaging;
-import org.springframework.context.annotation.Bean;
-import org.springframework.context.annotation.Configuration;
-import org.springframework.core.io.ClassPathResource;
-
-import java.io.FileInputStream;
-import java.io.IOException;
-import java.io.InputStream;
-import java.util.List;
-
-@Configuration
-public class FirebaseConfig {
-    @Bean
-    FirebaseMessaging firebaseMessaging() throws IOException {
-        ClassPathResource resource = new ClassPathResource("firebase/doyouknow-68e24-firebase-adminsdk-fbsvc-d1e410f852.json");
-
-        InputStream refreshToken = resource.getInputStream();
-
-        FirebaseApp firebaseApp = null;
-        List<FirebaseApp> firebaseAppList = FirebaseApp.getApps();
-
-        if (firebaseAppList != null && !firebaseAppList.isEmpty()) {
-            for (FirebaseApp app : firebaseAppList) {
-                if (app.getName().equals(FirebaseApp.DEFAULT_APP_NAME)) {
-                    firebaseApp = app;
-                }
-            }
-        } else {
-            FirebaseOptions options = FirebaseOptions.builder()
-                    .setCredentials(GoogleCredentials.fromStream(refreshToken))
-                    .build();
-
-            firebaseApp = FirebaseApp.initializeApp(options);
-        }
-
-        return FirebaseMessaging.getInstance(firebaseApp);
-    }
-
-}
+//package org.ayu.doyouknowback.config;
+//
+//import com.google.auth.oauth2.GoogleCredentials;
+//import com.google.firebase.FirebaseApp;
+//import com.google.firebase.FirebaseOptions;
+//import com.google.firebase.messaging.FirebaseMessaging;
+//import org.springframework.context.annotation.Bean;
+//import org.springframework.context.annotation.Configuration;
+//import org.springframework.core.io.ClassPathResource;
+//
+//import java.io.FileInputStream;
+//import java.io.IOException;
+//import java.io.InputStream;
+//import java.util.List;
+//
+//@Configuration
+//public class FirebaseConfig {
+//    @Bean
+//    FirebaseMessaging firebaseMessaging() throws IOException {
+//        ClassPathResource resource = new ClassPathResource("firebase/doyouknow-68e24-firebase-adminsdk-fbsvc-d1e410f852.json");
+//
+//        InputStream refreshToken = resource.getInputStream();
+//
+//        FirebaseApp firebaseApp = null;
+//        List<FirebaseApp> firebaseAppList = FirebaseApp.getApps();
+//
+//        if (firebaseAppList != null && !firebaseAppList.isEmpty()) {
+//            for (FirebaseApp app : firebaseAppList) {
+//                if (app.getName().equals(FirebaseApp.DEFAULT_APP_NAME)) {
+//                    firebaseApp = app;
+//                }
+//            }
+//        } else {
+//            FirebaseOptions options = FirebaseOptions.builder()
+//                    .setCredentials(GoogleCredentials.fromStream(refreshToken))
+//                    .build();
+//
+//            firebaseApp = FirebaseApp.initializeApp(options);
+//        }
+//
+//        return FirebaseMessaging.getInstance(firebaseApp);
+//    }
+//
+//}

--- a/src/main/java/org/ayu/doyouknowback/notice/controller/NoticeController.java
+++ b/src/main/java/org/ayu/doyouknowback/notice/controller/NoticeController.java
@@ -21,6 +21,21 @@ public class NoticeController {
 
     private final NoticeService noticeService;
 
+//    @GetMapping("/all") // 게시글 전체조회 ( paging 기능 구현 )
+//    public ResponseEntity<Page<NoticeResponseDTO>> getAllNotice(
+//            @RequestParam(required = false, defaultValue = "0") int page,
+//            @RequestParam(required = false, defaultValue = "10") int size,
+//            @RequestParam(required = false, defaultValue = "id,desc") String sort){
+//
+//        Page<NoticeResponseDTO> noticeResponseDTOList = noticeService.findAll(page, size, sort);
+//
+//        if (noticeResponseDTOList.isEmpty()) {
+//            return new ResponseEntity<>(HttpStatus.NO_CONTENT);
+//        } else return ResponseEntity.status(HttpStatus.OK).body(noticeResponseDTOList);
+//    }
+
+
+
     @GetMapping("/all") // 게시글 전체조회 ( paging 기능 구현 )
     public ResponseEntity<Page<NoticeResponseDTO>> getAllNotice(
             @RequestParam(required = false, defaultValue = "0") int page,

--- a/src/main/java/org/ayu/doyouknowback/notice/form/NoticeRequestDTO.java
+++ b/src/main/java/org/ayu/doyouknowback/notice/form/NoticeRequestDTO.java
@@ -16,6 +16,8 @@ public class NoticeRequestDTO {
     private String noticeDownloadLink; //다운로드 링크
     private String noticeDownloadTitle; //다운로드 제목
 
+
+
 //    @Builder
 //    public NoticeRequestDTO(String noticeTitle, String noticeDormitory, String noticeLink,
 //                            String noticeDate, String noticeCategory, int noticeViews, String noticeBody){

--- a/src/main/java/org/ayu/doyouknowback/notice/repository/NoticeRepository.java
+++ b/src/main/java/org/ayu/doyouknowback/notice/repository/NoticeRepository.java
@@ -2,6 +2,7 @@ package org.ayu.doyouknowback.notice.repository;
 
 import jakarta.validation.constraints.NotNull;
 import lombok.NonNull;
+import org.ayu.doyouknowback.lost.domain.Lost;
 import org.ayu.doyouknowback.notice.domain.Notice;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
@@ -27,6 +28,9 @@ public interface NoticeRepository extends JpaRepository<Notice, Long> {
     @NonNull
     Page<Notice> findByNoticeCategory(String noticeCategory, @NonNull Pageable pageable);
 
+    @NonNull
+    Page<Notice> findByNoticeTitleContainingOrNoticeBodyContaining(String value, String value1, Pageable pageable);
+
     // findByNoticeTitleContaining : 키워드 기준으로 검색하되, 쿼리로 작성(공지 제목, 작성자, 내용 필드 값 전부 참조)
     @Query("select "
             + "distinct n "
@@ -36,5 +40,7 @@ public interface NoticeRepository extends JpaRepository<Notice, Long> {
             + "   or n.noticeWriter like %:kw% "
             + "   or n.noticeBody like %:kw% ")
     Page<Notice> findAllByKeyWord(@Param("kw") String noticeSearchVal, Pageable pageable);
+
+
 
 }

--- a/src/main/java/org/ayu/doyouknowback/notice/scheduler/NoticeSchedulerConfiguration.java
+++ b/src/main/java/org/ayu/doyouknowback/notice/scheduler/NoticeSchedulerConfiguration.java
@@ -4,26 +4,25 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.scheduling.annotation.Scheduled;
 import org.springframework.stereotype.Component;
 
-import java.io.BufferedReader;
 import java.io.IOException;
-import java.io.InputStreamReader;
 
 @Component
 @RequiredArgsConstructor
 public class NoticeSchedulerConfiguration {
 
+
+
     // 매일 9시~18시 사이 매 30분마다 실행 (cron 설명: 초 분 시 일 월 요일)
-    @Scheduled(cron = "0 0/30 9-18 * * MON-FRI", zone = "Asia/Seoul")
-    //@Scheduled(cron = "0 * * * * *") // 1분마다 실행
+    //@Scheduled(cron = "0 0/30 9-18 * * *")
+    @Scheduled(cron = "0 * * * * *")
     public void runNoticePythonScript() {
         // 로컬 환경 개발용 주소
-        //String pythonScriptPath = "C:\\Doyouknow\\Doyouknow_Crawling\\notice.py";
+         String pythonScriptPath = "/Users/iminjun/Desktop/project/Doyouknow/Doyouknow_Crawling/notice.py";
 
-        // 도커 내 파일 경로
-        String pythonScriptPath = "/notice.py";
+        // 서버 환경용 주소
+        // String pythonScriptPath = "/home/ubuntu/크롤링폴더";
 
-        // 도커 내 python3 경로
-        ProcessBuilder processBuilder = new ProcessBuilder("/usr/bin/python3", pythonScriptPath);
+        ProcessBuilder processBuilder = new ProcessBuilder("python", pythonScriptPath);
 
         try {
             Process process = processBuilder.start();

--- a/src/main/java/org/ayu/doyouknowback/notice/service/NoticeService.java
+++ b/src/main/java/org/ayu/doyouknowback/notice/service/NoticeService.java
@@ -163,7 +163,9 @@ public class NoticeService {
 
         Pageable pageable = PageRequest.of(page, size, sorting);
 
-        Page<Notice> noticeList = noticeRepository.findAllByKeyWord(noticeSearchVal, pageable);
+        // Page<Notice> noticeList = noticeRepository.findAllByKeyWord(noticeSearchVal, pageable);
+
+        Page<Notice> noticeList = noticeRepository.findByNoticeTitleContainingOrNoticeBodyContaining(noticeSearchVal, noticeSearchVal, pageable);
 
         List<NoticeResponseDTO> responseDTOS = new ArrayList<>();
 


### PR DESCRIPTION
### PR 타입

[ ] 기능 추가
[ ] 기능 삭제
[✅] 버그 수정
[ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트

### 반영 브랜치

dev ← notice/search

### 발생 에러

공지사항 검색 시 게시글 제목, 내용에 포함되어 있는 키워드 를 검색할 경우 정상 작동하지만
DB 에 저장된 게시글의 제목 또는 내용에 포함되어 있지 않은 키워드 를 검색할 경우 공지사항 페이징 처리가 정상적으로 작동되지 않고
흰색 바탕화면과 함께 어떠한 동작도 시행되지 않음.

<img width="665" height="1440" alt="image" src="https://github.com/user-attachments/assets/c82a9d57-c48a-4ade-bc22-81e0a18dcdfc" />

<img width="665" height="1440" alt="image" src="https://github.com/user-attachments/assets/0f0cb0a7-2be7-4a1b-8942-dc0703ada609" />

### 에러 원인(추측)

@Query 사용으로 인한 에러로 추측됩니다.
JPQL + Pageable은 내부 최적화가 덜 되어 있어서, 조건이 충족되지 않으면 명확한 빈 Page를 반환하지 못할 수도 있음