### PR TITLE
Fix : 공지사항 예외된 검색 에러

### DIFF
--- a/src/main/java/org/ayu/doyouknowback/notice/repository/NoticeRepository.java
+++ b/src/main/java/org/ayu/doyouknowback/notice/repository/NoticeRepository.java
@@ -27,14 +27,17 @@ public interface NoticeRepository extends JpaRepository<Notice, Long> {
     @NonNull
     Page<Notice> findByNoticeCategory(String noticeCategory, @NonNull Pageable pageable);
 
+    @NonNull
+    Page<Notice> findByNoticeTitleContainingOrNoticeBodyContaining(String value, String value1, Pageable pageable);
+
     // findByNoticeTitleContaining : 키워드 기준으로 검색하되, 쿼리로 작성(공지 제목, 작성자, 내용 필드 값 전부 참조)
-    @Query("select "
-            + "distinct n "
-            + "from Notice n "
-            + "where "
-            + "   n.noticeTitle like %:kw% "
-            + "   or n.noticeWriter like %:kw% "
-            + "   or n.noticeBody like %:kw% ")
-    Page<Notice> findAllByKeyWord(@Param("kw") String noticeSearchVal, Pageable pageable);
+//    @Query("select "
+//            + "distinct n "
+//            + "from Notice n "
+//            + "where "
+//            + "   n.noticeTitle like %:kw% "
+//            + "   or n.noticeWriter like %:kw% "
+//            + "   or n.noticeBody like %:kw% ")
+//    Page<Notice> findAllByKeyWord(@Param("kw") String noticeSearchVal, Pageable pageable);
 
 }

--- a/src/main/java/org/ayu/doyouknowback/notice/service/NoticeService.java
+++ b/src/main/java/org/ayu/doyouknowback/notice/service/NoticeService.java
@@ -163,7 +163,7 @@ public class NoticeService {
 
         Pageable pageable = PageRequest.of(page, size, sorting);
 
-        Page<Notice> noticeList = noticeRepository.findAllByKeyWord(noticeSearchVal, pageable);
+        Page<Notice> noticeList = noticeRepository.findByNoticeTitleContainingOrNoticeBodyContaining(noticeSearchVal, noticeSearchVal, pageable);
 
         List<NoticeResponseDTO> responseDTOS = new ArrayList<>();
 


### PR DESCRIPTION
### PR 타입

[ ] 기능 추가
[ ] 기능 삭제
[✅] 버그 수정
[ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트

### 반영 브랜치

dev ← notice/search

### 발생 에러

공지사항 검색 시 게시글 제목, 내용에 포함되어 있는 키워드 를 검색할 경우 정상 작동하지만
DB 에 저장된 게시글의 제목 또는 내용에 포함되어 있지 않은 키워드 를 검색할 경우 공지사항 페이징 처리가 정상적으로 작동되지 않고
흰색 바탕화면과 함께 어떠한 동작도 시행되지 않음.

<img width="665" height="1440" alt="image" src="https://github.com/user-attachments/assets/102722e1-53b8-4e58-975a-535248c53517" />

<img width="665" height="1440" alt="image" src="https://github.com/user-attachments/assets/caf37917-28af-4666-9033-41a6184258c0" />

### 에러 원인(추측)

@query 사용으로 인한 에러로 추측됩니다.
JPQL + Pageable은 내부 최적화가 덜 되어 있어서, 조건이 충족되지 않으면 명확한 빈 Page를 반환하지 못할 수도 있음.